### PR TITLE
Fix Alt+Shift keyboard language switching when WebView2 has focus

### DIFF
--- a/google-chat-desktop/MainWindow.xaml.cs
+++ b/google-chat-desktop/MainWindow.xaml.cs
@@ -3,6 +3,7 @@ using google_chat_desktop.main.features;
 using Microsoft.Web.WebView2.Core;
 using System.Diagnostics;
 using System.IO;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -14,6 +15,20 @@ namespace google_chat_desktop
 {
     public partial class MainWindow : Window
     {
+        // P/Invoke for keyboard layout switching (workaround for WebView2 not forwarding Alt+Shift to OS)
+        [DllImport("user32.dll")]
+        private static extern IntPtr ActivateKeyboardLayout(IntPtr hkl, uint flags);
+
+        [DllImport("user32.dll")]
+        private static extern short GetKeyState(int nVirtKey);
+
+        private static readonly IntPtr HKL_NEXT = new(1);
+        private const uint KLF_SETFORPROCESS = 0x00000100;
+        private const int VK_SHIFT = 0x10;
+        private const int VK_MENU = 0x12; // Alt key
+
+        private bool _altShiftLangSwitchPending = false;
+
         private static MainWindow? instance;
         private static readonly Lock lockObject = new();
         private static readonly string appDirectory = AppDomain.CurrentDomain.BaseDirectory;
@@ -100,6 +115,7 @@ namespace google_chat_desktop
             webView.CoreWebView2.WebMessageReceived += CoreWebView2_WebMessageReceived;
             webView.CoreWebView2.PermissionRequested += CoreWebView2_PermissionRequested;
             webView.CoreWebView2.NavigationCompleted += CoreWebView2_NavigationCompleted;
+            webView.AcceleratorKeyPressed += WebView_AcceleratorKeyPressed;
 
             // WebView2 Configuration
             var settings = webView.CoreWebView2.Settings;
@@ -138,6 +154,40 @@ namespace google_chat_desktop
             }
         }
 
+
+        private void WebView_AcceleratorKeyPressed(object? sender, CoreWebView2AcceleratorKeyPressedEventArgs e)
+        {
+            uint vk = e.VirtualKey;
+            var kind = e.KeyEventKind;
+
+            bool isKeyDown = kind == CoreWebView2KeyEventKind.KeyDown ||
+                             kind == CoreWebView2KeyEventKind.SystemKeyDown;
+            bool isKeyUp = kind == CoreWebView2KeyEventKind.KeyUp ||
+                           kind == CoreWebView2KeyEventKind.SystemKeyUp;
+
+            if (vk == VK_MENU || vk == VK_SHIFT)
+            {
+                if (isKeyDown)
+                {
+                    bool altDown = (GetKeyState(VK_MENU) & 0x8000) != 0;
+                    bool shiftDown = (GetKeyState(VK_SHIFT) & 0x8000) != 0;
+
+                    if ((vk == VK_SHIFT && altDown) || (vk == VK_MENU && shiftDown))
+                        _altShiftLangSwitchPending = true;
+                }
+                else if (isKeyUp && _altShiftLangSwitchPending)
+                {
+                    _altShiftLangSwitchPending = false;
+                    ActivateKeyboardLayout(HKL_NEXT, KLF_SETFORPROCESS);
+                    e.Handled = true;
+                }
+            }
+            else
+            {
+                // Another key pressed while Alt+Shift held = shortcut, not language switch
+                _altShiftLangSwitchPending = false;
+            }
+        }
 
         private void CoreWebView2_PermissionRequested(object? sender, CoreWebView2PermissionRequestedEventArgs e)
         {


### PR DESCRIPTION
## Summary

- Fix Shift+Alt keyboard language switching not working when WebView2 has focus
- WebView2 intercepts Alt key combinations internally and does not forward them to the OS-level input language switching mechanism ([known WebView2 bug](https://github.com/MicrosoftEdge/WebView2Feedback/issues/3302))
- Uses `AcceleratorKeyPressed` event to detect Alt+Shift sequences, then calls `ActivateKeyboardLayout(HKL_NEXT)` to cycle keyboard layout

## How it works

1. On **key-down** of Shift (while Alt held) or Alt (while Shift held) → mark as pending
2. On **key-up** of either modifier while pending → call `ActivateKeyboardLayout(HKL_NEXT, KLF_SETFORPROCESS)`
3. On **any other key** pressed → cancel pending (it's a shortcut like Alt+Shift+I, not a language switch)

## Why this approach (vs `AllowHostInputProcessing`)

- **Targeted** — only intercepts Alt+Shift, no side effects on Tab/Escape/other keys
- `AllowHostInputProcessing` changes behavior of ALL key forwarding and requires workarounds for Tab and Escape
- Single-file change, easy to maintain

## Edge cases handled

- Both Alt→Shift and Shift→Alt key orderings
- Alt+Shift+letter treated as shortcut, not language switch
- Auto-repeat key events don't cause double-switching
- Win+Space unaffected (handled by OS directly)

Fixes #16